### PR TITLE
Fix for alignment view

### DIFF
--- a/src/c4/alignment.c
+++ b/src/c4/alignment.c
@@ -405,7 +405,7 @@ static void AlignmentView_add(AlignmentView *av,
     g_string_append(av->outer_target,  target_string);
     if(av->outer_query->len >= av->limit){
         apos = g_new(AlignmentPosition, 1);
-        apos->query_pos  = query_pos;
+        apos->query_pos  = query_pos + 2;
         apos->target_pos = target_pos;
         g_ptr_array_add(av->row_marker, apos);
         av->limit += av->width;


### PR DESCRIPTION
Added an offset of +2 to apos->query_pos to correct an error in the alignment view.

In alignment view, the target value is off by two for all but the last row of the display.

```
exonerate --alignmentwidth 46 unknown.seq P04247.fasta
Command line: [exonerate --alignmentwidth 46 /home/l/ljg2/unknown.seq /home/l/ljg2/P04247.fasta]
Hostname: [spectre11]

C4 Alignment:
------------
         Query: unknown
        Target: sp|P04247|MYG_MOUSE Myoglobin OS=Mus musculus GN=Mb PE=1 SV=3
         Model: ungapped:dna2protein
     Raw score: 171
   Query range: 128 -> 224
  Target range: 0 -> 32

 129 : atggggctcagtgatggggagtggcagctg : 156
       MetGlyLeuSerAspGlyGluTrpGlnLeu
       ||||||||||||||||||||||||||||||
   1 : MetGlyLeuSerAspGlyGluTrpGlnLeu :  10

 157 : gtgctgaatgtctgggggaaggtggaggcc : 186
       ValLeuAsnValTrpGlyLysValGluAla
       ||||||||||||||||||||||||||||||
  11 : ValLeuAsnValTrpGlyLysValGluAla :  20

 187 : gaccttgctggccatggacaggaagtcctc : 216
       AspLeuAlaGlyHisGlyGlnGluValLeu
       ||||||||||||||||||||||||||||||
  21 : AspLeuAlaGlyHisGlyGlnGluValLeu :  30

 217 : atcggg : 224
       IleGly
       ||||||
  31 : IleGly :  32

vulgar: unknown 128 224 + sp|P04247|MYG_MOUSE 0 32 . 171 M 96 32
-- completed exonerate analysis
```

It should be as so, differences are highlighted.

 129 : atggggctcagtgatggggagtggcagctg : **158**
       MetGlyLeuSerAspGlyGluTrpGlnLeu
       ||||||||||||||||||||||||||||||
   1 : MetGlyLeuSerAspGlyGluTrpGlnLeu :  10

 159 : gtgctgaatgtctgggggaaggtggaggcc : **188**
       ValLeuAsnValTrpGlyLysValGluAla
       ||||||||||||||||||||||||||||||
  11 : ValLeuAsnValTrpGlyLysValGluAla :  20

 189 : gaccttgctggccatggacaggaagtcctc : **218**
       AspLeuAlaGlyHisGlyGlnGluValLeu
       ||||||||||||||||||||||||||||||
  21 : AspLeuAlaGlyHisGlyGlnGluValLeu :  30

 219 : atcggg : 224
       IleGly
       ||||||
  31 : IleGly :  32
